### PR TITLE
Update github wrapper package name.

### DIFF
--- a/ghostjs-core/bin/ghostjs
+++ b/ghostjs-core/bin/ghostjs
@@ -1,10 +1,21 @@
 #!/usr/bin/env node
+var fs = require('fs')
+
+// Pass-through script to use mocha /w compilers
+var helperPath = 'node_modules/ghostjs/src/helper.js'
+
+// Mocha will require the path differently if we are installed via a git:// dependency.
+// The helper will be located in a matching location as the github source, instead of the top level module.
+var githubHelperPath = 'node_modules/ghostjs-github/ghostjs-core/src/helper.js'
+if (__dirname.includes('ghostjs/ghostjs-core/bin')) {
+  helperPath = githubHelperPath
+}
 
 // Pass-through script to use mocha /w compilers
 var spawn = require('child_process').spawn
 var argv = process.argv.slice(2).concat([
   '--require',
-  'node_modules/ghostjs/src/helper.js',
+  helperPath,
   '--timeout',
   '30000'
 ])

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ghostjs-github",
+  "name": "ghostjs",
   "version": "0.0.1",
   "description": "This is a wrapper so people can use git:// dependencies in package.json to install ghostjs. For the core package.json, see ghostjs-core/package.json.",
   "main": "ghostjs-core/src/ghostjs.js",


### PR DESCRIPTION
This will allow the test files to be detected whether they are in the top-level ghost directory, or in a sub-folder. This is necessary in order to allow for installation as a npm package or a git:// url.

This should fix #54 