### PR TITLE
Proxy countElements to findElements.length for now.

### DIFF
--- a/ghostjs-core/src/ghostjs.js
+++ b/ghostjs-core/src/ghostjs.js
@@ -241,15 +241,8 @@ class Ghost {
    */
   async countElements (selector) {
     console.log('countElements is deprecated, use findElements().length instead.')
-    return new Promise(resolve => {
-      this.pageContext.evaluate((selector) => {
-        return document.querySelectorAll(selector).length
-      },
-      selector,
-      (err, result) => {
-          resolve(result)
-        })
-    })
+    var collection = await this.findElements(selector);
+    return collection.length;
   }
 
   /**


### PR DESCRIPTION
Eventually we'll probably remove this method.