### PR TITLE
Specify longer timeout by default.

### DIFF
--- a/ghostjs-core/bin/ghostjs
+++ b/ghostjs-core/bin/ghostjs
@@ -15,10 +15,14 @@ if (__dirname.includes('ghostjs/ghostjs-core/bin')) {
 var spawn = require('child_process').spawn
 var argv = process.argv.slice(2).concat([
   '--require',
-  helperPath,
-  '--timeout',
-  '30000'
+  helperPath
 ])
+
+// Specify a long duration by default as integration tests can take a while to run.
+if (argv.indexOf('--timeout') === -1) {
+  argv.push('--timeout')
+  argv.push(5 * 60 * 1000)
+}
 
 // Lookup the locatin of mocha because it may have been installed at a different level.
 var mochaLocation = require.resolve('mocha')


### PR DESCRIPTION
Since most people are using this to run integration tests, having a longer timeout by default is useful to allow scripts to complete. This will allow people to override the default when passing --timeout into the command.