### PR TITLE
Specify mocha helper path as an env var.

### DIFF
--- a/ghostjs-core/bin/ghostjs
+++ b/ghostjs-core/bin/ghostjs
@@ -6,9 +6,9 @@ var helperPath = 'node_modules/ghostjs/src/helper.js'
 
 // Mocha will require the path differently if we are installed via a git:// dependency.
 // The helper will be located in a matching location as the github source, instead of the top level module.
-var githubHelperPath = 'node_modules/ghostjs-github/ghostjs-core/src/helper.js'
-if (__dirname.includes('ghostjs/ghostjs-core/bin')) {
-  helperPath = githubHelperPath
+// This is currenly specified in the top-level package.json
+if (process.env.GHOSTJS_HELPER_PATH) {
+  helperPath = process.env.GHOSTJS_HELPER_PATH
 }
 
 // Pass-through script to use mocha /w compilers

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": "git@github.com:KevinGrandon/ghostjs.git",
   "bin": {
-    "ghostjs": "./ghostjs-core/bin/ghostjs"
+    "ghostjs": "GHOSTJS_HELPER_PATH=node_modules/ghostjs-github/ghostjs-core/src/helper.js ./ghostjs-core/bin/ghostjs"
   },
   "scripts": {
     "postinstall": "(cd ghostjs-core && npm install)"


### PR DESCRIPTION
This allows consumers to utilize the package when it's installed via a git:// dependency.

Fixes #92 