### PR TITLE
Fix for ghostjs on windows

### DIFF
--- a/ghostjs-core/bin/ghostjs
+++ b/ghostjs-core/bin/ghostjs
@@ -31,7 +31,7 @@ var from = new RegExp('mocha\\' + path.sep + 'index.js$')
 var to = '.bin' + path.sep + 'mocha'
 mochaLocation = mochaLocation.replace(from, to)
 
-var child = spawn(mochaLocation, argv)
+var child = spawn(mochaLocation, argv, { shell: true })
 
 var stdout = ''
 var stderr = ''

--- a/ghostjs-core/bin/ghostjs
+++ b/ghostjs-core/bin/ghostjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 var fs = require('fs')
+var path = require('path')
 
 // Pass-through script to use mocha /w compilers
 var helperPath = 'node_modules/ghostjs/src/helper.js'
@@ -26,7 +27,9 @@ if (argv.indexOf('--timeout') === -1) {
 
 // Lookup the locatin of mocha because it may have been installed at a different level.
 var mochaLocation = require.resolve('mocha')
-mochaLocation = mochaLocation.replace(/mocha\/index\.js$/, '.bin/mocha')
+var from = new RegExp('mocha\\' + path.sep + 'index.js$')
+var to = '.bin' + path.sep + 'mocha'
+mochaLocation = mochaLocation.replace(from, to)
 
 var child = spawn(mochaLocation, argv)
 


### PR DESCRIPTION
Faced couple of problems when trying to run ghostjs on windows.

_First one:_ 

> internal/child_process.js:313
    throw errnoException(err, 'spawn');
    ^
> Error: spawn UNKNOWN
    at exports._errnoException (util.js:1022:11)
    at ChildProcess.spawn (internal/child_process.js:313:11)
    at exports.spawn (child_process.js:387:9)
    at Object.<anonymous> (C:\Users\mvmus\ghostjs_test\node_modules\ghostjs\bin\ghostjs:32:13)

This exception apeared when I were when trying to test from README.

_Second one:_
>Notepad with mocha's index.js file was opened instead of running test script.

Both problems were windows specific and both were fixed in cross-platform way. Tested on Windows and on macOS.