### PR TITLE
Prefer --browser argument instead of --ghost-driver.

### DIFF
--- a/ghostjs-core/README.md
+++ b/ghostjs-core/README.md
@@ -98,13 +98,11 @@ console.log(text)
 
 ### Chrome
 
-By default ghostjs will use Chrome as a test runner.
+By default ghostjs will use Chrome as a test runner, or when you pass `--browser chrome` as a command line argument. You will need to have chrome installed on your machine, but ghostjs will try to automatically locate the binary. You can specify a CHROME_BIN env var to override this location.
 
 ### PhantomJS
 
-By default ghostjs will use PhantomJS as a test runner. PhantomJS is installed as a dependency of the `ghostjs` package.
-
-You can choose to test on PhantomJS as a test runner by passing the `--browser phantom` option to the `ghostjs` command. E.g., you may have the following in your package.json:
+You can choose to test on PhantomJS as a test runner by passing the `--browser phantom` option to the `ghostjs` command. PhantomJS is installed as a dependency of the `ghostjs` package. E.g., you may have the following in your package.json:
 ```
 "scripts": {
   "test": "ghostjs --browser phantom test/*.js"  
@@ -113,7 +111,7 @@ You can choose to test on PhantomJS as a test runner by passing the `--browser p
 
 ### Firefox
 
-You can choose to test on Firefox (through SlimerJS) as a test runner by passing the `--browser firefox` option to the `ghostjs` command. E.g., you may have the following in your package.json:
+You can choose to test on Firefox (through SlimerJS) as a test runner by passing the `--browser firefox` option to the `ghostjs` command. Firefox must be installed on your computer to run tests against Firefox. E.g., you may have the following in your package.json:
 ```
 "scripts": {
   "test": "ghostjs --browser firefox test/*.js"  
@@ -127,7 +125,7 @@ before_script:
   - "sh -e /etc/init.d/xvfb start"
 ```
 
-You can see how we run both SlimerJS and PhantomJS tests in our example [package.json](https://github.com/KevinGrandon/ghostjs/blob/0bccf322b440f742b5c9e0e99ad39bcd19e5a853/ghostjs-examples/package.json#L8-L9) and our [.travis.yml](https://github.com/KevinGrandon/ghostjs/blob/79a2d070e3b5b20c1b25cc49828e9bf6941dec58/.travis.yml#L7-L10)
+You can see how we run both Chrome, Firefox and PhantomJS tests in our example [package.json](https://github.com/KevinGrandon/ghostjs/blob/0bccf322b440f742b5c9e0e99ad39bcd19e5a853/ghostjs-examples/package.json#L8-L9) and our [.travis.yml](https://github.com/KevinGrandon/ghostjs/blob/79a2d070e3b5b20c1b25cc49828e9bf6941dec58/.travis.yml#L7-L10)
 
 
 ### Babel

--- a/ghostjs-core/README.md
+++ b/ghostjs-core/README.md
@@ -96,24 +96,28 @@ console.log(text)
 
 ## Dependencies
 
+### Chrome
+
+By default ghostjs will use Chrome as a test runner.
+
 ### PhantomJS
 
 By default ghostjs will use PhantomJS as a test runner. PhantomJS is installed as a dependency of the `ghostjs` package.
 
-
-### SlimerJS
-
-You can choose to use SlimerJS as a test runner by passing the `--ghost-runner=slimerjs` option to the `ghostjs` command. E.g., you may have the following in your package.json:
+You can choose to test on PhantomJS as a test runner by passing the `--browser phantom` option to the `ghostjs` command. E.g., you may have the following in your package.json:
 ```
 "scripts": {
-  "test": "ghostjs --ghost-runner slimerjs test/*.js"  
+  "test": "ghostjs --browser phantom test/*.js"  
 }
 ```
 
-SlimerJS is not installed as a dependency by default, but you can add it to your project with:
+### Firefox
 
+You can choose to test on Firefox (through SlimerJS) as a test runner by passing the `--browser firefox` option to the `ghostjs` command. E.g., you may have the following in your package.json:
 ```
-npm install --save-dev slimerjs
+"scripts": {
+  "test": "ghostjs --browser firefox test/*.js"  
+}
 ```
 
 Note: SlimerJS is not headless and requires a windowing environment to run. If you are trying to run SlimerJS on travis, you can modify your travis.yml to have the following:

--- a/ghostjs-core/package.json
+++ b/ghostjs-core/package.json
@@ -27,6 +27,7 @@
     "node-phantom-simple": "^2.2.4",
     "phantomjs-prebuilt": "^2.1.7",
     "shelljs": "^0.7.7",
+    "slimerjs-core": "^0.12.0",
     "yargs": "^7.1.0"
   },
   "keywords": [

--- a/ghostjs-core/src/ghostjs.js
+++ b/ghostjs-core/src/ghostjs.js
@@ -12,7 +12,14 @@ class Ghost {
     // Default timeout per wait.
     this.waitTimeout = 30000
 
-    this.testRunner = argv['ghost-runner'] || 'phantomjs-prebuilt'
+    if (argv['browser'] === 'phantom') {
+      this.testRunner = 'phantomjs-prebuilt'
+    } else if(argv['browser'] === 'firefox') {
+      this.testRunner = 'firefox'
+    } else {
+      this.testRunner = 'chrome'
+    }
+
     this.driverOpts = null
     this.setDriverOpts({})
     this.browser = null
@@ -22,7 +29,7 @@ class Ghost {
     this.clientScripts = []
 
     // Open the console if we're running slimer, and the GHOST_CONSOLE env var is set.
-    if (this.testRunner.match(/slimerjs/) && process.env.GHOST_CONSOLE) {
+    if (this.testRunner.match(/firefox/) && process.env.GHOST_CONSOLE) {
       this.setDriverOpts({parameters: ['-jsconsole']})
     } else if (this.testRunner.match(/chrome/)) {
       const program = spawn(ChromeGhostDriver.path, [], {

--- a/ghostjs-core/src/ghostjs.js
+++ b/ghostjs-core/src/ghostjs.js
@@ -14,8 +14,8 @@ class Ghost {
 
     if (argv['browser'] === 'phantom') {
       this.testRunner = 'phantomjs-prebuilt'
-    } else if(argv['browser'] === 'firefox') {
-      this.testRunner = 'firefox'
+    } else if (argv['browser'] === 'firefox') {
+      this.testRunner = 'slimerjs-core'
     } else {
       this.testRunner = 'chrome'
     }
@@ -29,7 +29,7 @@ class Ghost {
     this.clientScripts = []
 
     // Open the console if we're running slimer, and the GHOST_CONSOLE env var is set.
-    if (this.testRunner.match(/firefox/) && process.env.GHOST_CONSOLE) {
+    if (this.testRunner.match(/slimerjs/) && process.env.GHOST_CONSOLE) {
       this.setDriverOpts({parameters: ['-jsconsole']})
     } else if (this.testRunner.match(/chrome/)) {
       const program = spawn(ChromeGhostDriver.path, [], {

--- a/ghostjs-core/src/ghostjs.js
+++ b/ghostjs-core/src/ghostjs.js
@@ -51,6 +51,11 @@ class Ghost {
         ? opts
         : {}
 
+    // Don't do anything for chrome here.
+    if (this.testRunner.match(/chrome/)) {
+      return
+    }
+
     if (opts.parameters) {
       this.driverOpts.parameters = opts.parameters
     }

--- a/ghostjs-examples/package.json
+++ b/ghostjs-examples/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "npm run test:phantom && npm run test:slimerjs && npm run test:chrome",
-    "test:chrome": "ghostjs --ghost-runner ghostjs-chrome-adapter test/*.js",
-    "test:phantom": "ghostjs test/*.js",
-    "test:slimerjs": "ghostjs --ghost-runner slimerjs-firefox test/*.js"
+    "test:chrome": "ghostjs --browser chrome test/*.js",
+    "test:phantom": "ghostjs --browser phantom test/*.js",
+    "test:slimerjs": "ghostjs --browser firefox test/*.js"
   },
   "author": "Kevin Grandon <kevingrandon@yahoo.com>",
   "license": "MPL-2.0",


### PR DESCRIPTION
Allows for something like:

```
"test:chrome": "ghostjs --browser chrome test/*.js",
"test:phantom "ghostjs --browser phantom test/*.js",
"test:firefox "ghostjs --browser firefox test/*.js"
```

