### PR TITLE
[Proposal] Add new methods -- ghost.click and ghost.fill

### DIFF
--- a/ghostjs-core/README.md
+++ b/ghostjs-core/README.md
@@ -31,6 +31,8 @@ npm install ghostjs
 * `await ghost.waitForElementVisible(selector)` - Waits for an element to exist and be visible on the page.
 * `await ghost.waitForPage(string)` - Waits for the a page to be opened opened with the given url (or string search), via window.open.
 * `await ghost.waitForPageTitle(string|RegExp)` - Waits for the page title to match the expected value.
+* `await ghost.click(selector)` - Clicks on an element specified by the selector, by default in the center of the element.
+* `await ghost.fill(selector, text)` - Fills a form field with the provided value. Tries to set the right value for non-text inputs.
 * `await element.click(x?, y?)` - Clicks the element, by default in the center of the element.
 * `await element.getAttribute(attribute)` - Returns the value of an attribute for this element
 * `await element.html()` - Returns the innerHTML of an element.

--- a/ghostjs-core/src/ghostjs.js
+++ b/ghostjs-core/src/ghostjs.js
@@ -513,17 +513,17 @@ class Ghost {
    * @param {String} selector
    */
   async click (selector) {
-    const el = await this.waitForElement(selector);
-    await el.click(); 
+    const el = await this.waitForElement(selector)
+    await el.click()
   }
 
   /**
-   * Fills an input with a specified value 
-   * @param {String} selector 
+   * Fills an input with a specified value
+   * @param {String} selector
    */
   async fill (selector, fillValue) {
-    const el = await this.waitForElement(selector);
-    await el.fill(fillValue);
+    const el = await this.waitForElement(selector)
+    await el.fill(fillValue)
   }
 }
 

--- a/ghostjs-core/src/ghostjs.js
+++ b/ghostjs-core/src/ghostjs.js
@@ -507,6 +507,24 @@ class Ghost {
     console.log('waitFor is deprecated, use wait(fn) instead.')
     return this.wait(func, pollMs)
   }
+
+  /**
+   * Clicks on an element specified by the selector
+   * @param {String} selector
+   */
+  async click (selector) {
+    const el = await this.waitForElement(selector);
+    await el.click(); 
+  }
+
+  /**
+   * Fills an input with a specified value 
+   * @param {String} selector 
+   */
+  async fill (selector, fillValue) {
+    const el = await this.waitForElement(selector);
+    await el.fill(fillValue);
+  }
 }
 
 var ghost = new Ghost()

--- a/ghostjs-examples/test/ghost_click.js
+++ b/ghostjs-examples/test/ghost_click.js
@@ -1,0 +1,16 @@
+import ghost from 'ghostjs'
+import assert from 'assert'; 
+
+import localServer from './fixtures/server.js'
+
+describe('ghost#click', () => {
+  before(localServer)
+  after(localServer.stop)
+
+  it ('Properly clicks on an element', async () => { 
+    await ghost.open('http://localhost:8888/basic_content.html');
+
+    await ghost.click('#formLink');
+    await ghost.waitForPageTitle('Form');
+  });
+});

--- a/ghostjs-examples/test/ghost_fill_test.js
+++ b/ghostjs-examples/test/ghost_fill_test.js
@@ -1,0 +1,69 @@
+import ghost from 'ghostjs';
+import assert from 'assert';
+
+import localServer from './fixtures/server.js';
+
+describe('ghost#fill', () => {
+
+  before(localServer)
+  after(localServer.stop)
+
+  it('fills the form', async () => {
+    await ghost.open('http://localhost:8888/form.html')
+
+    // input[type=text]
+    let emptyInput = await ghost.findElement('#emptyInput')
+    assert.equal(await emptyInput.getAttribute('value'), '')
+    await ghost.fill('#emptyInput', 'text input filled')
+    assert.equal(await emptyInput.getAttribute('value'), 'text input filled')
+
+    // input[type=text] (filled)
+    await ghost.fill('#emptyInput', '')
+    assert.equal(await emptyInput.getAttribute('value'), '')
+
+    // textarea
+    let emptyTextarea = await ghost.findElement('#emptyTextarea')
+    assert.equal(await emptyTextarea.getAttribute('value'), '')
+    await ghost.fill('#emptyTextarea', 'textarea filled')
+    assert.equal(await emptyTextarea.getAttribute('value'), 'textarea filled')
+
+    // checkboxes
+    let firstCheckbox = await ghost.findElement('#checkbox1')
+    let secondCheckbox = await ghost.findElement('#checkbox2')
+    assert.equal(await firstCheckbox.getAttribute('checked'), false)
+    assert.equal(await secondCheckbox.getAttribute('checked'), false)
+    await ghost.fill('#checkbox2', true)
+    assert.equal(await firstCheckbox.getAttribute('checked'), false)
+    assert.equal(await secondCheckbox.getAttribute('checked'), true)
+
+    // radios
+    let firstRadio = await ghost.findElement('#radio1')
+    let secondRadio = await ghost.findElement('#radio2')
+    assert.equal(await firstRadio.getAttribute('checked'), false)
+    assert.equal(await secondRadio.getAttribute('checked'), false)
+    await ghost.fill('#radio1', true)
+    assert.equal(await firstRadio.getAttribute('checked'), true)
+    assert.equal(await secondRadio.getAttribute('checked'), false)
+
+    // select
+    let singleSelect = await ghost.findElement('#singleSelect')
+    assert.equal(await singleSelect.getAttribute('value'), '1')
+    await ghost.fill('#singleSelect', 'Second Value');
+    assert.equal(await singleSelect.getAttribute('value'), '2')
+
+    // multiple
+    let multiSelect = await ghost.findElement('#multiSelect')
+    await ghost.fill('#multiSelect', ['one', 'two'])
+    // Verbose, we can make a helper if anyone does this.
+    var selected = await multiSelect.script((el) => {
+      var selected = []
+      for (var i = 0; i < el.options.length; i++) {
+        if (el.options[i].selected) {
+          selected.push(el.options[i].value)
+        }
+      }
+      return selected
+    })
+    assert.deepEqual([1, 2], selected)
+  })
+})


### PR DESCRIPTION
A common use case for `ghost` is to click on elements or fill inputs with certain values. Right now, each of these is a two-line operation that looks something like
```js
const el = ghost.findElement('#someSelector')
el.click()

const myInput = ghost.findElement('#someInput');
myInput.fill('foo bar')
``` 

In order to improve developer ergonomics, this PR adds the `click()` and `fill()` methods into the Ghost object itself.  So now, the above example can be consolidated into: 

```js
ghost.click('#someSelector');
ghost.fill('#someInput', 'foo bar');
```

This PR also updates the documentation about the methods available on the ghost object, as well as modifies existing texts with the new methods.