### PR TITLE
Fix import from Chrome binary causing Chrome to always open

### DIFF
--- a/ghostjs-core/package.json
+++ b/ghostjs-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghostjs",
-  "version": "1.12.1",
+  "version": "1.13.0",
   "description": "Modern web integration test runner",
   "main": "src/ghostjs.js",
   "author": "Kevin Grandon <kevingrandon@yahoo.com>",

--- a/ghostjs-core/src/chrome/binary
+++ b/ghostjs-core/src/chrome/binary
@@ -3,6 +3,7 @@
 const shell = require('shelljs')
 const spawn = require('child_process').spawn
 const fs = require('fs')
+const getChromeFlags = require('../utils').getChromeFlags
 
 const getPath = () => {
 	if (process.platform === 'darwin') {
@@ -16,15 +17,6 @@ const chromePath = process.env.CHROME_BIN || getPath()
 
 var isFirst = true
 var stderr = ''
-
-function getChromeFlags() {
-  let args = [];
-  if (process.env.CHROME_FLAGS) {
-    const chromeFlags = process.env.CHROME_FLAGS.split(',')
-    args = args.concat(chromeFlags)
-  }
-  return args
-}
 
 const program = spawn(
   chromePath,
@@ -52,7 +44,3 @@ process.on('SIGTERM', function() {
   cp.kill('SIGTERM')
   process.exit(1)
 })
-
-module.exports = {
-  getChromeFlags
-}

--- a/ghostjs-core/src/ghostjs.js
+++ b/ghostjs-core/src/ghostjs.js
@@ -2,7 +2,7 @@
 import Element from './element'
 
 // For testing purposes
-import { getChromeFlags } from './chrome/binary'
+import { getChromeFlags } from './utils'
 
 var debug = require('debug')('ghost')
 var driver = require('node-phantom-simple')
@@ -84,7 +84,7 @@ class Ghost {
       this.setDriverOpts({parameters: ['-jsconsole']})
     } else if (this.testRunner.match(/chrome/)) {
       const program = spawn(ChromeGhostDriver.path, [], {
-        cwd: root,
+        cwd: process.cwd(),
         env: process.env
       })
       program.stdout.pipe(process.stdout)

--- a/ghostjs-core/src/utils.js
+++ b/ghostjs-core/src/utils.js
@@ -1,5 +1,5 @@
-function getChromeFlags() {
-  let args = [];
+function getChromeFlags () {
+  let args = []
   if (process.env.CHROME_FLAGS) {
     const chromeFlags = process.env.CHROME_FLAGS.split(',')
     args = args.concat(chromeFlags)

--- a/ghostjs-core/src/utils.js
+++ b/ghostjs-core/src/utils.js
@@ -1,0 +1,10 @@
+function getChromeFlags() {
+  let args = [];
+  if (process.env.CHROME_FLAGS) {
+    const chromeFlags = process.env.CHROME_FLAGS.split(',')
+    args = args.concat(chromeFlags)
+  }
+  return args
+}
+
+module.exports = { getChromeFlags }


### PR DESCRIPTION
I had done a silly thing importing from the `binary` script, which caused Chrome to be spawned even if I had specified a `--browser firefox`

Takes the util function out of the binary script and puts it in a separate utils.js file.