### PR TITLE
Bug: Chrome browser exit async missing

### DIFF
--- a/ghostjs-core/src/chrome/index.js
+++ b/ghostjs-core/src/chrome/index.js
@@ -276,8 +276,8 @@ ChromePageObject.create = (options, callback) => {
     createPage: (pageCb) => {
       pageCb(null, pageObj)
     },
-    exit: () => {
-      pageObj.closeAll()
+    exit: async () => {
+      await pageObj.closeAll()
     }
   })
 }


### PR DESCRIPTION
This PR adds the async keyword to the browser exit method to properly await completion of closing.